### PR TITLE
fix: use identity-based cache to prevent query collisions

### DIFF
--- a/docs/2-cache-collision/1_research.md
+++ b/docs/2-cache-collision/1_research.md
@@ -1,0 +1,43 @@
+# Cache collision in ConvexTestProvider
+
+> GitHub Issue: [#2](https://github.com/siraj-samsudeen/convex-test-provider/issues/2)
+
+## Context
+
+When a React component uses multiple `useQuery` calls under `ConvexTestProvider`, the internal cache in the fake client can return the wrong data to a query hook. This shows up as type mismatches at runtime (e.g. an array query receiving a string result) and can crash components.
+
+## Ecosystems Consulted
+
+- Convex React client patterns — Convex uses function identity and structured serialization internally to distinguish queries and their arguments in its watcher cache.
+
+## Options Considered
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Keep `JSON.stringify({ query, args })` but patch convex-test client | Minimal code change | `anyApi` proxies stringify to `{}`, so different functions still collide; brittle and tied to current convex internals | Rejected |
+| Use `JSON.stringify` only on `args` and use function reference identity for the query key (nested `Map`) | Fixes collisions between different query functions; keeps simple, deterministic key for args | Still relies on `JSON.stringify` for args equality; acceptable for test-only client but not perfect generalization | **Chosen** |
+| Assign synthetic IDs per `watchQuery` call (pure identity-based cache) | Guaranteed no collisions | Loses sharing between identical `(query, args)` calls; harder to reason about cache behaviour | Rejected |
+| Try to reach into Convex internals to read the query path/name | Would exactly match real Convex client behaviour | Couples this package to Convex private APIs; more fragile than necessary | Rejected |
+
+## Key Q&A
+
+**Q:** Why is there a collision when using multiple `useQuery` calls with no args?  
+**A:** The current implementation serializes the `query` function via `JSON.stringify` when building the cache key. Convex's `anyApi` proxy produces function objects that stringify to `"{}"`, so all such functions share the same serialized representation. With no args, every query shares the same key and overwrites each other's cache entries.
+
+**Q:** Do we need to exactly match Convex's production cache semantics?  
+**A:** No. This provider is a thin adapter around `convex-test` for component tests. We only need stable, non-colliding keys per `(query, args)` pair and behaviour that is close enough that React hooks see the right data.
+
+**Q:** Why not use deep equality on `args` instead of `JSON.stringify`?  
+**A:** For this test helper a simple `JSON.stringify` on `args` is sufficient and keeps the implementation small. If future tests need more robust arg handling we can iterate, but the root problem here is query-function collisions, which using function identity directly solves.
+
+## Final Design
+
+Use a two-level cache keyed by query function identity and by a stringified `args` key:
+
+- Replace the single `Map<string, unknown>` cache with `Map<unknown, Map<string, unknown>>`.
+- In `watchQuery`, look up (or create) the inner `Map` for the `query` function.
+- Compute `const argsKey = JSON.stringify(args ?? {})`.
+- Store and read results from `queryCache.get(argsKey)` / `set(argsKey, result)`.
+
+This preserves sharing for identical `(query, args)` pairs while preventing collisions between different query functions that previously serialized to the same JSON string.
+

--- a/docs/2-cache-collision/2_spec.md
+++ b/docs/2-cache-collision/2_spec.md
@@ -1,0 +1,51 @@
+# Cache collision Specification
+
+> GitHub Issue: [#2](https://github.com/siraj-samsudeen/convex-test-provider/issues/2)
+
+## Overview
+
+`ConvexTestProvider` currently computes its query cache key as `JSON.stringify({ query, args })`. When used with Convex's `anyApi` proxy, different query functions stringify to identical `{}` objects, so multiple `useQuery` calls in the same component can return each other's results. This specification defines the required behaviour and constraints for a corrected cache implementation.
+
+## Requirements
+
+### R1: Unique cache entries per `(query, args)` pair
+
+Each distinct combination of query function reference and arguments must have its own cache entry. Two different query functions called with the same arguments must not share a cache slot.
+
+### R2: Stable identity-based query key
+
+The cache must use the query function's reference identity (the object/function itself) to distinguish queries, not its JSON representation or other lossy serialization.
+
+### R3: Deterministic argument keying
+
+For a given query function, calls with the same logical argument object should hit the same cache entry. For this package, it is acceptable to use `JSON.stringify(args ?? {})` as the argument key, assuming arguments are plain JSON-serializable data.
+
+### R4: Backwards-compatible public API
+
+The public `ConvexTestProvider` component and its `ConvexTestClient` interface must not change. Existing tests that use a single `useQuery` call or only `useMutation` should continue to pass.
+
+### R5: Regression test for multiple `useQuery` calls
+
+There must be at least one automated test that:
+
+- Uses a component with two `useQuery` calls to different Convex queries, and
+- Asserts that each hook receives data from its own query rather than the other, and
+- Would fail against the pre-fix implementation.
+
+## Constraints
+
+### C1: Keep implementation small and readable
+
+The fake client is intentionally minimal for use in tests. The new cache logic should remain simple and avoid unnecessary abstractions or deep dependency on Convex internals.
+
+### C2: No behavioural change to mutation forwarding
+
+The `mutation` path must continue to simply forward to `client.mutation` without additional caching or side effects.
+
+## Acceptance Criteria
+
+- [ ] A new failing test is added that demonstrates the cache collision when running against the old implementation.
+- [ ] After the cache change, the new test passes and existing tests in `ConvexTestProvider.test.tsx` continue to pass.
+- [ ] The implementation uses query function identity plus a deterministic arg key for caching, not `JSON.stringify({ query, args })`.
+- [ ] The issue's described scenario (multiple `useQuery` calls in the same component) is no longer reproducible when using `ConvexTestProvider`.
+

--- a/docs/2-cache-collision/3_plan.md
+++ b/docs/2-cache-collision/3_plan.md
@@ -1,0 +1,52 @@
+# Cache collision Implementation Plan
+
+> GitHub Issue: [#2](https://github.com/siraj-samsudeen/convex-test-provider/issues/2)
+
+## Files to Modify
+
+- `src/ConvexTestProvider.tsx` — update the cache implementation used by the fake client.
+- `src/ConvexTestProvider.test.tsx` — add a regression test that uses multiple `useQuery` calls in a single component.
+
+## Implementation Steps
+
+### Step 1: Add regression test for multiple `useQuery` calls
+
+1. In `ConvexTestProvider.test.tsx`, define a test component that:
+   - Calls `useQuery` for two different Convex queries (e.g. `api.items.list` and another simple query you introduce for testing).
+   - Renders both results in a way that can be asserted independently.
+2. Seed the backend so that the two queries return distinguishable values (for example, a list length vs. a specific string).
+3. Add a new `it("supports multiple useQuery calls without cache collisions", ...)` test that:
+   - Renders the component under `ConvexTestProvider`.
+   - Waits for both query results.
+   - Asserts that each `useQuery` receives the expected value from its own query.
+4. Run `npm test` (or `npm run test`) and confirm this new test fails against the current implementation, demonstrating the bug.
+
+### Step 2: Replace string-based cache key with identity-based structure
+
+1. In `ConvexTestProvider.tsx`, replace the existing `const cache = new Map<string, unknown>();` with:
+   - `const cache = new Map<unknown, Map<string, unknown>>();` so that:
+     - The outer `Map` is keyed by the query function reference.
+     - The inner `Map` is keyed by a stringified representation of `args`.
+2. Update `watchQuery`:
+   - Look up (or lazily create) an inner `Map` for the current `query`:
+     - `let queryCache = cache.get(query);`  
+       `if (!queryCache) { queryCache = new Map(); cache.set(query, queryCache); }`
+   - Compute `const argsKey = JSON.stringify(args ?? {});`.
+   - On `client.query(...).then(...)`, store the result in `queryCache.set(argsKey, result)` and then notify the subscriber.
+   - Implement `localQueryResult` to read from `queryCache.get(argsKey)`.
+3. Keep the `subscriber` logic and `mutation` forwarding behaviour unchanged.
+
+### Step 3: Run and verify tests
+
+1. Run the full test suite (e.g. `npm test`).
+2. Confirm:
+   - All existing tests still pass.
+   - The new regression test for multiple `useQuery` calls now passes.
+3. Optionally, run the tests multiple times to ensure there are no flakiness issues introduced by the new cache logic.
+
+## Verification Checklist
+
+- [ ] Regression test fails before the implementation change and passes after.
+- [ ] No TypeScript errors or linter issues are introduced in the modified files.
+- [ ] `ConvexTestProvider` continues to work for existing single-`useQuery` components and for mutations.
+


### PR DESCRIPTION
## Summary
- Replace `JSON.stringify({ query, args })` cache key with a two-level `Map<unknown, Map<string, unknown>>` keyed by query function identity and stringified args
- Fixes cache collisions when multiple `useQuery` calls share the same component (anyApi proxies all stringify to `"{}"`)
- Add regression test with two different queries (`api.items.list` + `api.todos.list`) asserting each receives its own data

Closes #2

## Documentation
- [Research](docs/2-cache-collision/1_research.md)
- [Spec](docs/2-cache-collision/2_spec.md)
- [Plan](docs/2-cache-collision/3_plan.md)

## Test plan
- [x] New regression test `supports multiple useQuery calls without cache collisions` passes
- [x] All existing tests continue to pass (8/8)
- [x] Manual: verify with a real app using multiple `useQuery` in one component (Verified it with my app by installing my fork)

🤖 Generated with [Claude Code](https://claude.com/claude-code)