### PR TITLE
Add review-convex-tests as a project skill (interim home for #15)

### DIFF
--- a/.claude/skills/review-convex-tests/SKILL.md
+++ b/.claude/skills/review-convex-tests/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: review-convex-tests
+description: "Review Convex test files against the 12-point checklist in TESTING-PHILOSOPHY.md. Flags weak assertions, wrong test layers, DSL misuse, and coverage shortcuts."
+allowed-tools:
+  - Read
+  - Bash
+---
+
+<objective>
+Review Convex test code against the 13-point checklist below. Works in two modes:
+- **File mode**: reviews one or more `.test.ts` / `.test.tsx` files on disk
+- **Plan mode**: given a `.md` plan file, extracts embedded test code blocks and reviews those
+
+Load the reference files before reviewing. Report every violation with location, severity, and a concrete fix.
+</objective>
+
+---
+
+## Step 1 — Identify what to review
+
+**If given a `.md` file (plan mode):** Extract all TypeScript/TSX code blocks that contain `test(` or `it(`. Treat each block as a virtual test file named after its surrounding subtask heading. Review the extracted code — no files need to exist on disk.
+
+**If given `.test.ts` / `.test.tsx` file paths:** Read and review those files directly.
+
+**If given nothing:** Review all test files changed in the current branch:
+
+```bash
+git diff --name-only main | grep -E "\.test\.(ts|tsx)$"
+```
+
+If that returns nothing, ask: "Which test file(s) or plan file should I review?"
+
+---
+
+## Step 2 — Load references
+
+Read these before reviewing — they contain the ❌/✅ examples and API details you need:
+
+- `references/data-seeding.md` — seed() vs testClient.run(), multi-user patterns, auth table traps
+- `references/session-dsl.md` — Session DSL method table, chaining vs sequential awaits, Playwright-only methods
+- `references/one-shot-workarounds.md` — why queries don't re-run after mutations, three workarounds
+- `references/auth-testing.md` — withIdentity subject format, { authenticated: false } timing, authTables trap
+
+---
+
+## Step 3 — Apply the checklist
+
+For each test file, check all 12 points. Read the full file before flagging — some patterns are only wrong in context.
+
+### 1. No mocked backend for data-display tests
+If a component calls `useQuery` and displays the result, it must be an integration test with `renderWithSession` + data seeding — not a mock of `useQuery`. Mocking `useQuery` for a state that a real in-memory backend would return is the wrong layer.
+
+**Exception:** loading state (`useQuery` returns `undefined`) — always Mock, never Integration. See `references/data-seeding.md`.
+
+### 2. No redundant backend-only tests
+If an integration test renders a component that calls `api.X.Y`, a separate backend-only test for `api.X.Y` is redundant. The integration test covers both layers.
+
+### 3. Mocks ONLY for transient or unreachable states
+Legitimate mock targets: loading spinners (`useQuery → undefined`), error states that can't be produced from a real backend, states blocked by auth guards in production code. Everything else: push to integration.
+
+### 4. seed() vs testClient.run() — use seed() for normal data
+```tsx
+// ❌ Verbose
+await testClient.run(async (ctx: any) => ctx.db.insert("todos", { text: "Buy milk" }));
+
+// ✅ Concise
+await seed("todos", { text: "Buy milk" });
+```
+Exception: `authTables` (users, sessions, accounts, verificationCodes) — use `testClient.run()` because `seed()` bypasses auth validators. See `references/data-seeding.md`.
+
+### 5. Session DSL for interactions — and chain calls, don't sequential-await
+```tsx
+// ❌ Verbose userEvent + screen
+await userEvent.type(screen.getByLabelText("Email"), "a@b.com");
+await userEvent.click(screen.getByRole("button", { name: "Submit" }));
+
+// ❌ Sequential awaits — breaks DSL chaining contract
+await session.fillIn("Email", "a@b.com");
+await session.clickButton("Submit");
+
+// ✅ Single chained await
+await session.fillIn("Email", "a@b.com").clickButton("Submit");
+```
+Multiple sequential `await session.X()` calls are a flag — chain them instead.
+
+### 6. findByText for async data, not getByText
+Data from `useQuery` resolves asynchronously. `getByText` throws immediately if the element isn't present yet. Every integration test that waits for backend data must use `findByText` or `findByRole`.
+
+### 7. Not asserting stale UI after mutations
+With `ConvexTestProvider`, queries are one-shot — they don't re-run after mutations. See `references/one-shot-workarounds.md` for the three valid patterns.
+
+### 8. Multi-user tests pass explicit userId to seed()
+Without an explicit `userId`, `seed()` auto-fills the default test user. Multi-user tests must pass `userId` explicitly:
+```tsx
+const bob = await createUser();
+await seed("todos", { text: "Bob's todo", userId: bob.userId });
+```
+
+### 9. MECE design — no overlap, no gaps
+One test per visual state. No two tests cover the same state; no state is left untested. Within each test, assert multiple aspects of that state. See [TESTING-PHILOSOPHY.md — The MECE Testing Framework].
+
+### 10. No snapshot tests
+Any `toMatchSnapshot()` is a flag. Replace with specific assertions against user-visible text, roles, and counts.
+
+### 11. Assertions verify user-visible behavior, not execution
+Every assertion must answer: "Would this fail if the component returned an empty div?" Flag:
+- `expect(x).toBeDefined()` — proves nothing
+- `expect(x).toBeTruthy()` — proves nothing
+- `expect(container).toBeInTheDocument()` — proves mounting, not rendering
+
+Every integration test needs at least one `findByText`, `findByRole`, or `getByText` proving real user-visible content rendered.
+
+### 12. Test names describe what the user sees
+Pattern: `"[verb] [what the user sees] [condition if needed]"`. Never "should". Never implementation-focused names like "handles the error case" or "renders correctly".
+
+### 13. Inline arrow handlers in JSX are separate V8 coverage entries
+```tsx
+// onClick={() => doThing()} is a separate function entry in V8 coverage
+// If no test clicks this button, it shows 0% in the functions metric
+```
+Flag any `onClick={() => ...}` (or similar inline handlers) where no test action triggers that button/element.
+
+---
+
+## Step 4 — Report
+
+Output a numbered list. For each finding:
+- Location: file + line number for file mode; subtask heading + line within the code block for plan mode
+- Which checklist point it violates
+- Why it matters in practice (one sentence)
+- Concrete fix (code snippet if helpful)
+- Severity: `[BLOCKER]` (will fail coverage gate or produce false confidence), `[GAP]` (wrong layer or missing test), `[IMPROVEMENT]` (cleaner pattern)
+
+End with: "N blockers, M gaps, P improvements found."
+
+Do not apply fixes — report only. The user decides what to change.

--- a/.claude/skills/review-convex-tests/references/auth-testing.md
+++ b/.claude/skills/review-convex-tests/references/auth-testing.md
@@ -1,0 +1,60 @@
+# Auth Testing Reference
+
+## withIdentity — subject format
+
+`testClient.withIdentity({ subject: userId })` works correctly when `userId` is a raw `Id<"users">` string. The `@convex-dev/auth` library's `getAuthUserId` implementation splits the subject on `"|"` to separate provider prefix from the ID. A raw Convex `Id<"users">` contains no pipe character, so it is used as-is — no special formatting needed.
+
+```tsx
+const userId = await testClient.run(async (ctx: any) =>
+  ctx.db.insert("users", { email: "alice@example.com" }),
+);
+// Works — userId is a plain Id<"users"> string with no "|"
+const authed = testClient.withIdentity({ subject: userId });
+```
+
+## authTables — use testClient.run(), not seed()
+
+The `authTables` tables (`users`, `sessions`, `accounts`, `verificationCodes`) are created by `@convex-dev/auth` with document validators. `seed()` bypasses auth context but not document validators — inserting a plain `{ email }` object into `users` via `seed()` will throw a validator error.
+
+```tsx
+// ❌ Throws — authTables has document validators that reject plain inserts
+await seed("users", { email: "alice@example.com" });
+
+// ✅ testClient.run() uses ctx.db directly, bypassing validators
+const userId = await testClient.run(async (ctx: any) =>
+  ctx.db.insert("users", { email: "alice@example.com" }),
+);
+```
+
+## { authenticated: false } — skip async auth subscription settle
+
+`renderWithSession` with a real auth identity waits for the auth subscription to settle before resolving. In practice this adds ~1 second per test. When the test does not need an authenticated user, pass `{ authenticated: false }` to skip this wait:
+
+```tsx
+// ❌ Waits ~1s for auth settle even though we don't need auth
+const session = renderWithSession(<App />, testClient);
+
+// ✅ Skips auth settle — fast
+const session = renderWithSession(<App />, testClient, { authenticated: false });
+await session.assertText("Sign in");
+```
+
+Pass `{ authenticated: false }` for any unauthenticated state test. Only omit it (or pass a real identity via `withIdentity`) when the test actually needs an authenticated user.
+
+## Testing the "user deleted after auth" branch
+
+The `user?.email ?? null` branch (where a query looks up an authenticated user that no longer exists) is reachable in `convex-test` via `db.delete()`. This branch does NOT need a `/* v8 ignore */` annotation.
+
+```tsx
+test("viewer returns null when user document is deleted after auth", async ({ testClient }) => {
+  const userId = await testClient.run(async (ctx: any) =>
+    ctx.db.insert("users", { email: "x@example.com" }),
+  );
+  const authed = testClient.withIdentity({ subject: userId });
+  await testClient.run(async (ctx: any) => ctx.db.delete(userId));
+  const result = await authed.query(api.users.viewer, {});
+  expect(result).toBeNull();
+});
+```
+
+`convex-test`'s `DatabaseFake` returns `null` for deleted IDs — `db.get(deletedId)` is `null`, making this branch deterministically reachable.

--- a/.claude/skills/review-convex-tests/references/data-seeding.md
+++ b/.claude/skills/review-convex-tests/references/data-seeding.md
@@ -1,0 +1,56 @@
+# Data Seeding Reference
+
+## seed() — the default
+
+`seed()` is a fixture available in integration tests. It inserts a row into the given table and auto-fills `userId` with the default test user.
+
+```tsx
+test("shows task list", async ({ client, seed }) => {
+  await seed("todos", { title: "Buy milk", completed: false });
+  const session = renderWithSession(<TodoList />, client);
+  await session.assertText("Buy milk");
+});
+```
+
+Use `seed()` for all ordinary application tables.
+
+## testClient.run() — for auth tables and complex setups
+
+`seed()` is a thin wrapper around a Convex mutation that bypasses normal auth context. `authTables` (the `users`, `sessions`, `accounts`, and `verificationCodes` tables created by `@convex-dev/auth`) have validators that reject plain object inserts — `seed()` will throw.
+
+For auth tables, use `testClient.run()` to insert directly via the internal `ctx.db` API, which bypasses validators:
+
+```tsx
+const userId = await testClient.run(async (ctx: any) =>
+  ctx.db.insert("users", { email: "alice@example.com" }),
+);
+```
+
+This is also the pattern for any setup that needs to return the inserted ID (for use in `withIdentity` or further setup).
+
+## Multi-user tests
+
+Without an explicit `userId`, `seed()` inserts as the default test user. For multi-user scenarios, pass `userId` explicitly:
+
+```tsx
+const alice = await createUser();
+const bob = await createUser();
+await seed("todos", { title: "Alice's task", userId: alice.userId });
+await seed("todos", { title: "Bob's task", userId: bob.userId });
+```
+
+## Deleted-row testing
+
+To test behavior when a row is deleted after auth (e.g., the `user?.email ?? null` branch in a viewer query), insert with `testClient.run()`, capture the ID, then delete it:
+
+```tsx
+const userId = await testClient.run(async (ctx: any) =>
+  ctx.db.insert("users", { email: "x@example.com" }),
+);
+const authed = testClient.withIdentity({ subject: userId });
+await testClient.run(async (ctx: any) => ctx.db.delete(userId));
+const result = await authed.query(api.users.viewer, {});
+expect(result).toBeNull();
+```
+
+`db.get(deletedId)` returns `null` in convex-test's `DatabaseFake` — this branch is reachable and does not warrant a `/* v8 ignore */` annotation.

--- a/.claude/skills/review-convex-tests/references/one-shot-workarounds.md
+++ b/.claude/skills/review-convex-tests/references/one-shot-workarounds.md
@@ -1,0 +1,52 @@
+# One-Shot Query Workarounds
+
+## Why queries don't re-run after mutations
+
+`ConvexTestProvider` (the integration test backend) runs queries once at mount time. Unlike the production Convex client, it does not watch for changes and re-run queries when data changes. This means:
+
+```tsx
+// ❌ This does NOT work — query has already resolved; the list won't update
+await testClient.run(async (ctx) => ctx.db.insert("todos", { text: "New item" }));
+expect(screen.getByText("New item")).toBeInTheDocument(); // fails
+```
+
+## Three valid workarounds
+
+### 1. Assert backend state directly (preferred for mutation tests)
+
+Skip the UI entirely — query the backend after the mutation:
+
+```tsx
+test("adds a todo", async ({ client, seed }) => {
+  const session = renderWithSession(<AddTodo />, client);
+  await session.fillIn("Task", "Buy milk").clickButton("Add");
+
+  const todos = await client.query(api.todos.list, {});
+  expect(todos).toHaveLength(1);
+  expect(todos[0].text).toBe("Buy milk");
+});
+```
+
+### 2. Re-mount the component
+
+Unmount and re-render to trigger a fresh query:
+
+```tsx
+const { unmount } = renderWithSession(<TodoList />, client);
+await client.mutation(api.todos.add, { text: "Buy milk" });
+unmount();
+const session2 = renderWithSession(<TodoList />, client);
+await session2.assertText("Buy milk");
+```
+
+### 3. Use TanStack Query provider
+
+`renderWithSession` has a `tanstackQuery: true` option that wraps the component with a TanStack Query provider. This provider auto-invalidates queries after mutations, giving live-update behavior:
+
+```tsx
+const session = renderWithSession(<TodoList />, client, { tanstackQuery: true });
+await session.fillIn("Task", "Buy milk").clickButton("Add");
+await session.assertText("Buy milk"); // works — query re-ran after mutation
+```
+
+Use TanStack Query when testing reactive UI updates (list updates, count changes, filter changes). Use backend assertions when testing that mutations persisted correctly.

--- a/.claude/skills/review-convex-tests/references/session-dsl.md
+++ b/.claude/skills/review-convex-tests/references/session-dsl.md
@@ -1,0 +1,89 @@
+# Session DSL Reference
+
+The Session DSL is a fluent interface shared across Integration (React Testing Library adapter) and E2E (Playwright adapter) tests. Methods queue up and execute on `await`.
+
+## Method table
+
+| Method | Integration | E2E | Description |
+|--------|-------------|-----|-------------|
+| `fillIn(label, value)` | ✅ | ✅ | Types into the field with the given accessible label |
+| `clickButton(name)` | ✅ | ✅ | Clicks the button with the given accessible name |
+| `assertText(text)` | ✅ | ✅ | Asserts the text is visible on screen |
+| `refuteText(text)` | ✅ | ✅ | Asserts the text is NOT visible |
+| `click(selector)` | ✅ | ✅ | Clicks an arbitrary element |
+| `submit(formName?)` | ✅ | ✅ | Submits a form |
+| `within(selector, fn)` | ✅ | ✅ | Scopes subsequent assertions to a DOM subtree |
+| `visit(path)` | ❌ | ✅ | Navigates to a URL — Playwright only |
+| `assertPath(path)` | ❌ | ✅ | Asserts the current URL path — Playwright only |
+| `assertHas(selector)` | ❌ | ✅ | Asserts an element exists — Playwright only |
+| `refuteHas(selector)` | ❌ | ✅ | Asserts an element does not exist — Playwright only |
+
+Do not use Playwright-only methods in integration tests — they will throw.
+
+## Chaining, not sequential awaits
+
+Methods return `this`, enabling a fluent chain. The chain executes when `await`ed.
+
+```tsx
+// ❌ Sequential awaits — each line creates a new execution context
+await session.fillIn("Email", "a@b.com");
+await session.clickButton("Sign in");
+await session.assertText("Welcome");
+
+// ✅ Single chained await
+await session
+  .fillIn("Email", "a@b.com")
+  .clickButton("Sign in")
+  .assertText("Welcome");
+```
+
+Sequential `await session.X()` calls are not an error — they work — but they break the contract of the DSL. The chained form is required by convention.
+
+## assertText accepts strings only
+
+`assertText` takes a plain string, not a React element or JSX. Passing a React element will silently fail the assertion.
+
+```tsx
+// ❌ JSX element
+await session.assertText(<span>Welcome, alice!</span>);
+
+// ✅ Plain string
+await session.assertText("Welcome, alice!");
+```
+
+## within() for scoped assertions
+
+When the same text appears in multiple places, scope the assertion:
+
+```tsx
+await session
+  .within(".todo-list", async (s) => {
+    await s.assertText("Buy milk");
+  })
+  .within(".completed-list", async (s) => {
+    await s.refuteText("Buy milk");
+  });
+```
+
+## Creating a session
+
+**Integration:**
+```tsx
+const session = renderWithSession(<App />, testClient.withIdentity({ subject: userId }));
+await session.assertText("Welcome");
+```
+
+**Integration (unauthenticated):**
+```tsx
+const session = renderWithSession(<App />, testClient, { authenticated: false });
+await session.assertText("Sign in");
+```
+
+**E2E (Playwright):**
+```tsx
+test("user signs in", async ({ session }) => {
+  await session
+    .visit("/")
+    .assertText("Sign in");
+});
+```


### PR DESCRIPTION
Refs #15.

Moves the 13-point TESTING-PHILOSOPHY checklist reviewer (`review-convex-tests` + its four reference docs) into this repo's `.claude/skills/`, next to the `TESTING-PHILOSOPHY.md` it enforces. Until now it existed only as a global skill on Siraj's machine — invisible to other machines, teammates, and consumers.

This is the interim home; #15 tracks the real end-state of shipping it inside the npm package with an `ai-files`-style installer so consumer projects (featherbase et al.) get it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
